### PR TITLE
Make writes non-destructive

### DIFF
--- a/test_serialization.py
+++ b/test_serialization.py
@@ -29,3 +29,16 @@ def test_serializer(tmpdir):
     db.insert({'int': 2})
     assert db.count(where('date') == date) == 1
     assert db.count(where('int') == 2) == 1
+
+
+def test_serializer_nondestructive(tmpdir):
+    path = str(tmpdir.join('db.json'))
+
+    serializer = SerializationMiddleware(JSONStorage)
+    serializer.register_serializer(DateTimeSerializer(), 'TinyDate')
+    db = TinyDB(path, storage=serializer)
+
+    data = {'date': datetime.utcnow(), 'int': 3}
+    data_before = dict(data)  # implicitly copy
+    db.insert(data)
+    assert data == data_before

--- a/tinydb_serialization/__init__.py
+++ b/tinydb_serialization/__init__.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
+from copy import deepcopy
 from tinydb import TinyDB
 from tinydb.middlewares import Middleware
 from tinydb.utils import with_metaclass
@@ -92,6 +93,10 @@ class SerializationMiddleware(Middleware):
         return data
 
     def write(self, data):
+        # Work with a copy of the data, so that running a serializer does not
+        # overwrite the original object.
+        data = deepcopy(data)
+
         for serializer_name in self._serializers:
             # If no serializers are registered, this code will just look up
             # the serializer list and continue. But if there are serializers,

--- a/tinydb_serialization/__init__.py
+++ b/tinydb_serialization/__init__.py
@@ -93,9 +93,9 @@ class SerializationMiddleware(Middleware):
         return data
 
     def write(self, data):
-        # Work with a copy of the data, so that running a serializer does not
-        # overwrite the original object.
-        data = deepcopy(data)
+        # We only make a copy of the data if any serializer would overwrite
+        # existing data.
+        data_copied = False
 
         for serializer_name in self._serializers:
             # If no serializers are registered, this code will just look up
@@ -119,6 +119,11 @@ class SerializationMiddleware(Middleware):
                             tagged = '{{{0}}}:{1}'.format(serializer_name,
                                                           encoded)
 
-                            item[field] = tagged
+                            # Before writing, copy data if we haven't already.
+                            if not data_copied:
+                                 data = deepcopy(data)
+                                 data_copied = True
+
+                            data[table_name][eid][field] = tagged
 
         self.storage.write(data)


### PR DESCRIPTION
I noticed, while working on [recipy](/recipy/recipy), that calling `db.insert(data)` on a dict with the DateTimeSerializer enabled will change `data` in-place, replacing each `datetime` with the serialized string. My fix is to do a `deepcopy` of the data dict as the first step of `write`. Not the most efficient, but it does the trick.
