### PR TITLE
Fix original element being mutated when it contains list fields

### DIFF
--- a/test_serialization.py
+++ b/test_serialization.py
@@ -38,7 +38,7 @@ def test_serializer_nondestructive(tmpdir):
     serializer.register_serializer(DateTimeSerializer(), 'TinyDate')
     db = TinyDB(path, storage=serializer)
 
-    data = {'date': datetime.utcnow(), 'int': 3}
+    data = {'date': datetime.utcnow(), 'int': 3, 'list': []}
     data_before = dict(data)  # implicitly copy
     db.insert(data)
     assert data == data_before

--- a/tinydb_serialization/__init__.py
+++ b/tinydb_serialization/__init__.py
@@ -100,7 +100,7 @@ def has_encodable(element, obj_class):
 
     for key, value in _enumerate_element(element):
         if isinstance(value, (dict, list, tuple)):
-            return has_encodable(value, obj_class)
+            found_encodable |= has_encodable(value, obj_class)
         else:
             found_encodable |= isinstance(value, obj_class)
 


### PR DESCRIPTION
When an element is inserted to the database, the original object should not be mutated when serialised. This is generally honoured, except when the element contains list fields, due to a bug when recursing over the lists.