### PR TITLE
Remove import of JSONStorage from README example code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,6 @@ You can use your serializer like this:
 .. code-block:: python
 
     >>> from tinydb import TinyDB
-    >>> from tinydb.storages import JSONStorage
     >>> from tinydb_serialization import SerializationMiddleware
     >>> from tinydb import Query
     >>>


### PR DESCRIPTION
Hi!

Seeing the JSONStorage imported but not used in the example code of the README confused me. After seeing the code, I see it is optional, so why bother importing it ?