### PR TITLE
Fix: "Type[type]" is incompatible with "Type[property]"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*$py.class
 
 # C extensions
 *.so
 
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -19,9 +19,12 @@ lib64/
 parts/
 sdist/
 var/
+wheels/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -36,12 +39,17 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
 
 # Translations
 *.mo
@@ -49,9 +57,96 @@ coverage.xml
 
 # Django stuff:
 *.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
 
 # Sphinx documentation
 docs/_build/
 
 # PyBuilder
+.pybuilder/
 target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/tinydb_serialization/__init__.py
+++ b/tinydb_serialization/__init__.py
@@ -12,15 +12,14 @@ class Serializer(ABC):
     """
     The abstract base class for Serializers.
     Allows TinyDB to handle arbitrary objects by running them through a list
-    of registerd serializers.
+    of registered serializers.
     Every serializer has to tell which class it can handle.
     """
 
     @property
     @abstractmethod
     def OBJ_CLASS(self):
-        raise NotImplementedError('To be overriden!')
-
+        raise NotImplementedError('To be overridden!')
     @abstractmethod
     def encode(self, obj):
         """
@@ -29,7 +28,7 @@ class Serializer(ABC):
         :return:
         :rtype: str
         """
-        raise NotImplementedError('To be overriden!')
+        raise NotImplementedError('To be overridden!')
 
     @abstractmethod
     def decode(self, s):
@@ -39,7 +38,7 @@ class Serializer(ABC):
         :type s: str
         :return:
         """
-        raise NotImplementedError('To be overriden!')
+        raise NotImplementedError('To be overridden!')
 
 
 def _enumerate_element(element):
@@ -91,20 +90,20 @@ def _encode_deep(element, serializer, tag, obj_class):
             _encode_deep(value, serializer, tag, obj_class)
 
 
-def has_encodable(element, obj_class):
+def has_encodeable(element, obj_class):
     """
-    Check whether the element in question has an encodable item.
+    Check whether the element in question has an encodeable item.
     """
 
-    found_encodable = False
+    found_encodeable = False
 
     for key, value in _enumerate_element(element):
         if isinstance(value, (dict, list, tuple)):
-            found_encodable |= has_encodable(value, obj_class)
+            found_encodeable |= has_encodeable(value, obj_class)
         else:
-            found_encodable |= isinstance(value, obj_class)
+            found_encodeable |= isinstance(value, obj_class)
 
-    return found_encodable
+    return found_encodeable
 
 
 class SerializationMiddleware(Middleware):
@@ -174,7 +173,7 @@ class SerializationMiddleware(Middleware):
 
                 for eid in table:
                     # Before writing, copy data if we haven't already.
-                    if not data_copied and has_encodable(data[table_name][eid],
+                    if not data_copied and has_encodeable(data[table_name][eid],
                                                          obj_class):
                         data = deepcopy(data)
                         data_copied = True

--- a/tinydb_serialization/__init__.py
+++ b/tinydb_serialization/__init__.py
@@ -16,10 +16,8 @@ class Serializer(ABC):
     Every serializer has to tell which class it can handle.
     """
 
-    @property
-    @abstractmethod
-    def OBJ_CLASS(self):
-        raise NotImplementedError('To be overridden!')
+    OBJ_CLASS: object
+
     @abstractmethod
     def encode(self, obj):
         """


### PR DESCRIPTION
Pylance in VSCode issues: 
Expression of type "OBJ_CLASS" cannot be assigned to declared type "property"
  "Type[type]" is incompatible with "Type[property]"
 
 - removed property/abstractmethod OBJ_CLASS and only defined OBJ_CLASS, by omitting the initial value, leaves the variable uninitialized
 
other changes:
 - update .gitignore (from https://github.com/github/gitignore/blob/main/Python.gitignore)
    with this, a created directory .venv is also ignored
 - fix misspelled words